### PR TITLE
Attach Eliza FE to Eve Deployment

### DIFF
--- a/Dockerfile.eve
+++ b/Dockerfile.eve
@@ -19,6 +19,8 @@ COPY eliza/package.json eliza/pnpm-lock.yaml eliza/pnpm-workspace.yaml eliza/.np
 
 # Copy the rest of the application code
 COPY eliza/agent ./agent
+COPY eliza/client ./client
+COPY eliza/lerna.json ./
 COPY eliza/packages ./packages
 COPY eliza/scripts ./scripts
 COPY eliza/characters ./characters
@@ -48,6 +50,8 @@ COPY --from=builder /app/.npmrc ./
 COPY --from=builder /app/turbo.json ./
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/agent ./agent
+COPY --from=builder /app/client ./client
+COPY --from=builder /app/lerna.json ./
 COPY --from=builder /app/packages ./packages
 COPY --from=builder /app/scripts ./scripts
 COPY --from=builder /app/characters ./characters

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     platform: linux/amd64
     ports:
       - "8000:80"
+      - "5173:5173"
     image: eve-agent:latest
 
 

--- a/start.sh
+++ b/start.sh
@@ -2,4 +2,5 @@ echo "Starting nginx"
 nginx -g "daemon off;" &
 
 echo "Starting node server"
-pnpm start --characters="app/characters/eve.character.json"
+pnpm start --characters="app/characters/eve.character.json" &
+pnpm start:client --host


### PR DESCRIPTION
By default the FE is set to port 5173, we can change this by adding `--port <port>` to the last line of `start.sh`, i.e.

```start.sh
pnpm start:client --host --port <port>
```

set up dockerfile for client build, start.sh to include start command, and docker-compose to expose the associated port