### PR TITLE
Add deployment scripts for prod. Add alembic migration. Update servers. 

### DIFF
--- a/.github/workflows/create-new-runtime-service-staging.yaml
+++ b/.github/workflows/create-new-runtime-service-staging.yaml
@@ -13,6 +13,12 @@ jobs:
     new-service:
         runs-on: ubuntu-latest
         steps:
+            - name: Fail if no service number is provided
+              run: |
+                  if [ -z "${{ inputs.service-no }}" ]; then
+                      echo "No service number provided"
+                      exit 1
+                  fi
             - name: Configure aws credentials for ELB
               uses: aws-actions/configure-aws-credentials@v4
               with:
@@ -23,7 +29,7 @@ jobs:
               run: |
 
                   TARGET_GROUP_ARN=$(aws elbv2 create-target-group \
-                  --name "aiden-runtime-staging${{ inputs.service-no }}" \
+                  --name "aiden-runtime-staging-${{ inputs.service-no }}" \
                   --protocol HTTP \
                   --port 80 \
                   --vpc-id vpc-028f84ceaa7ceffdf \

--- a/.github/workflows/create-new-runtime-service-staging.yaml
+++ b/.github/workflows/create-new-runtime-service-staging.yaml
@@ -7,7 +7,6 @@ on:
             service-no:
                 description: "Service number for the new runtime service"
                 required: true
-    pull_request:
 
 jobs:
     new-service:

--- a/.github/workflows/create-new-runtime-service-staging.yaml
+++ b/.github/workflows/create-new-runtime-service-staging.yaml
@@ -81,7 +81,7 @@ jobs:
                   aws ecs create-service \
                     --cluster AidenStaging \
                     --launch-type FARGATE \
-                    --service-name "aiden-runtime-staging${{ inputs.service-no }}" \
+                    --service-name "aiden-runtime-staging-${{ inputs.service-no }}" \
                     --task-definition arn:aws:ecs:us-east-1:008971649127:task-definition/aiden-agent-runtime-staging \
                     --desired-count 1 \
                     --load-balancers "[{

--- a/.github/workflows/create-new-runtime-service-staging.yaml
+++ b/.github/workflows/create-new-runtime-service-staging.yaml
@@ -1,5 +1,5 @@
-run-name: Create new runtime service
-name: Create new runtime service
+run-name: Create new runtime service for staging
+name: Create new runtime service for staging
 
 on:
     workflow_dispatch:
@@ -22,7 +22,7 @@ jobs:
               run: |
 
                   TARGET_GROUP_ARN=$(aws elbv2 create-target-group \
-                  --name "aiden-runtime-${{ inputs.service-no }}" \
+                  --name "aiden-runtime-staging${{ inputs.service-no }}" \
                   --protocol HTTP \
                   --port 80 \
                   --vpc-id vpc-028f84ceaa7ceffdf \
@@ -43,7 +43,7 @@ jobs:
                     --listener-arn arn:aws:elasticloadbalancing:us-east-1:008971649127:listener/app/aiden-staging/cca8548986966f89/681e2c72542f3c11 \
                     --conditions "[{
                         \"Field\": \"host-header\",
-                        \"Values\": [\"aiden-runtime-${{ inputs.service-no }}.aiden.space\"]
+                        \"Values\": [\"staging.aiden-runtime-${{ inputs.service-no }}.aiden.space\"]
                         }]" \
                     --actions "[{
                         \"Type\": \"forward\",
@@ -56,7 +56,7 @@ jobs:
                     --listener-arn arn:aws:elasticloadbalancing:us-east-1:008971649127:listener/app/aiden-staging/cca8548986966f89/0e71c1863b9f0654 \
                     --conditions "[{
                       \"Field\": \"host-header\",
-                      \"Values\": [\"aiden-runtime-${{ inputs.service-no }}.aiden.space\"]
+                      \"Values\": [\"staging.aiden-runtime-${{ inputs.service-no }}.aiden.space\"]
                       }]" \
                     --actions "[{
                         \"Type\": \"forward\",
@@ -75,7 +75,7 @@ jobs:
                   aws ecs create-service \
                     --cluster AidenStaging \
                     --launch-type FARGATE \
-                    --service-name "aiden-runtime-${{ inputs.service-no }}" \
+                    --service-name "aiden-runtime-staging${{ inputs.service-no }}" \
                     --task-definition arn:aws:ecs:us-east-1:008971649127:task-definition/aiden-agent-runtime-staging \
                     --desired-count 1 \
                     --load-balancers "[{

--- a/.github/workflows/create-new-runtime-service-staging.yaml
+++ b/.github/workflows/create-new-runtime-service-staging.yaml
@@ -7,6 +7,7 @@ on:
             service-no:
                 description: "Service number for the new runtime service"
                 required: true
+    pull_request:
 
 jobs:
     new-service:

--- a/.github/workflows/create-new-runtime-service.yaml
+++ b/.github/workflows/create-new-runtime-service.yaml
@@ -7,7 +7,6 @@ on:
             service-no:
                 description: "Service number for the new runtime service"
                 required: true
-    pull_request:
 
 jobs:
     new-service:

--- a/.github/workflows/create-new-runtime-service.yaml
+++ b/.github/workflows/create-new-runtime-service.yaml
@@ -1,0 +1,96 @@
+run-name: Create new runtime service
+name: Create new runtime service
+
+on:
+    workflow_dispatch:
+        inputs:
+            service-no:
+                description: "Service number for the new runtime service"
+                required: true
+
+jobs:
+    new-service:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Configure aws credentials for ELB
+              uses: aws-actions/configure-aws-credentials@v4
+              with:
+                  role-to-assume: arn:aws:iam::008971649127:role/AIDEN_GHA_ELB
+                  aws-region: us-east-1
+
+            - name: Register new target group
+              run: |
+
+                  TARGET_GROUP_ARN=$(aws elbv2 create-target-group \
+                  --name "aiden-runtime-${{ inputs.service-no }}" \
+                  --protocol HTTP \
+                  --port 80 \
+                  --vpc-id vpc-002b5682c46769515 \
+                  --target-type ip \
+                  --health-check-path "/ping" \
+                  --health-check-interval-seconds 30 \
+                  --query "TargetGroups[0].TargetGroupArn" \
+                  --output text)
+
+                  echo "TARGET_GROUP_ARN=$TARGET_GROUP_ARN" >> $GITHUB_ENV
+
+            - name: Register new rules
+              run: |
+                  PRIORITY=$((100 + ${{ inputs.service-no }})) 
+
+                  # HTTP listener
+                  aws elbv2 create-rule \
+                    --listener-arn arn:aws:elasticloadbalancing:us-east-1:008971649127:listener/app/aiden/c75e38614c895163/0418e5a3323e20fc \
+                    --conditions "[{
+                        \"Field\": \"host-header\",
+                        \"Values\": [\"aiden-runtime-${{ inputs.service-no }}.aiden.space\"]
+                        }]" \
+                    --actions "[{
+                        \"Type\": \"forward\",
+                        \"TargetGroupArn\": \"${{ env.TARGET_GROUP_ARN }}\"
+                        }]" \
+                    --priority $PRIORITY
+
+                  # HTTPS listener
+                  aws elbv2 create-rule \
+                    --listener-arn arn:aws:elasticloadbalancing:us-east-1:008971649127:listener/app/aiden/c75e38614c895163/5ccef0a9112d870c \
+                    --conditions "[{
+                      \"Field\": \"host-header\",
+                      \"Values\": [\"aiden-runtime-${{ inputs.service-no }}.aiden.space\"]
+                      }]" \
+                    --actions "[{
+                        \"Type\": \"forward\",
+                        \"TargetGroupArn\": \"${{ env.TARGET_GROUP_ARN }}\"
+                        }]" \
+                    --priority $PRIORITY
+
+            - name: Configure aws credentials for ECS
+              uses: aws-actions/configure-aws-credentials@v4
+              with:
+                  role-to-assume: arn:aws:iam::008971649127:role/AIDEN_GHA_ECS
+                  aws-region: us-east-1
+
+            - name: Create new service
+              run: |
+                  aws ecs create-service \
+                    --cluster 
+                    --launch-type FARGATE \
+                    --service-name "aiden-runtime-${{ inputs.service-no }}" \
+                    --task-definition arn:aws:ecs:us-east-1:008971649127:task-definition/aiden-agent-runtime \
+                    --desired-count 1 \
+                    --load-balancers "[{
+                        \"targetGroupArn\": \"${{ env.TARGET_GROUP_ARN }}\",
+                        \"containerName\": \"runtime\",
+                        \"containerPort\": 80
+                        }]" \
+                    --network-configuration "{
+                        \"awsvpcConfiguration\": {
+                            \"subnets\": [\"subnet-03609df324958be8e\", \"subnet-0643691ae2f5f1e32\"],
+                            \"securityGroups\": [\"sg-08dd9f6f9ecc9bfe9\"],
+                            \"assignPublicIp\": \"ENABLED\"
+                            }
+                        }"
+
+permissions:
+    id-token: write
+    contents: read

--- a/.github/workflows/create-new-runtime-service.yaml
+++ b/.github/workflows/create-new-runtime-service.yaml
@@ -13,6 +13,12 @@ jobs:
     new-service:
         runs-on: ubuntu-latest
         steps:
+            - name: Fail if no service number is provided
+              run: |
+                  if [ -z "${{ inputs.service-no }}" ]; then
+                      echo "No service number provided"
+                      exit 1
+                  fi
             - name: Configure aws credentials for ELB
               uses: aws-actions/configure-aws-credentials@v4
               with:

--- a/.github/workflows/create-new-runtime-service.yaml
+++ b/.github/workflows/create-new-runtime-service.yaml
@@ -7,6 +7,7 @@ on:
             service-no:
                 description: "Service number for the new runtime service"
                 required: true
+    pull_request:
 
 jobs:
     new-service:

--- a/.github/workflows/deploy-aiden-to-prod.yaml
+++ b/.github/workflows/deploy-aiden-to-prod.yaml
@@ -1,0 +1,23 @@
+run-name: Deploy Aiden API to prod
+name: Deploy Aiden API to prod
+
+on:
+    workflow_dispatch:
+
+jobs:
+    force-redeployment:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Configure aws credentials
+              uses: aws-actions/configure-aws-credentials@v4
+              with:
+                  role-to-assume: arn:aws:iam::008971649127:role/AIDEN_GHA_ECS
+                  aws-region: us-east-1
+
+            - name: Force redeployment
+              run: |
+                  aws ecs update-service --cluster Aiden --service aiden-api --force-new-deployment
+
+permissions:
+    id-token: write
+    contents: read

--- a/.github/workflows/deploy-frontend-to-prod.yaml
+++ b/.github/workflows/deploy-frontend-to-prod.yaml
@@ -1,0 +1,23 @@
+run-name: Deploy frontend to prod
+name: Deploy frontend to prod
+
+on:
+    workflow_dispatch:
+
+jobs:
+    force-redeployment:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Configure aws credentials
+              uses: aws-actions/configure-aws-credentials@v4
+              with:
+                  role-to-assume: arn:aws:iam::008971649127:role/AIDEN_GHA_ECS
+                  aws-region: us-east-1
+
+            - name: Force redeployment
+              run: |
+                  aws ecs update-service --cluster Aiden --service aiden-frontend --force-new-deployment
+
+permissions:
+    id-token: write
+    contents: read

--- a/apps/api/Dockerfile.api
+++ b/apps/api/Dockerfile.api
@@ -5,7 +5,6 @@ COPY --from=ghcr.io/astral-sh/uv:0.4.27 /uv /uvx /bin/
 WORKDIR /api
 
 COPY . .
-RUN mv src/.env.api.example src/.env.api
 # Locally, docker-compose loads .env.api
 # On aws, task definition loads from secrets manager.
 

--- a/apps/api/src/__init__.py
+++ b/apps/api/src/__init__.py
@@ -1,8 +1,13 @@
+import logging
 import os
 from logging import getLogger
 
 from dotenv import load_dotenv
 
+logging.basicConfig(
+    level=os.getenv("LOG_LEVEL", "INFO"),
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
 logger = getLogger(__name__)
 
 dir_path = os.path.dirname(os.path.realpath(__file__))

--- a/apps/api/src/alembic/env.py
+++ b/apps/api/src/alembic/env.py
@@ -1,10 +1,13 @@
+import logging
 import os
-from logging.config import fileConfig
 
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 from sqlalchemy.engine.url import URL
 from sqlmodel import SQLModel
+
+# from logging.config import fileConfig
+
 
 pass  # Prevent isort from reordering imports
 from src.db.models import *  # noqa
@@ -15,8 +18,17 @@ config = context.config
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
-if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+# if config.config_file_name is not None:
+#     fileConfig(config.config_file_name)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    handlers=[logging.StreamHandler()],
+)
+
+# Enable log propagation for Alembic
+logging.getLogger("alembic").propagate = True
 
 # add your model's MetaData object here
 # for 'autogenerate' support

--- a/apps/api/src/db/crud.py
+++ b/apps/api/src/db/crud.py
@@ -30,9 +30,9 @@ def create_generic(session: Session, model: M) -> M:
 
 
 def update_generic(session: Session, model: M, model_update: N) -> M:
-    fields_payload = model_update.model_dump(exclude_none=True)
-    for value in fields_payload:
-        setattr(model, value, fields_payload[value])
+    fields_payload = model_update.model_dump(exclude_unset=True)
+    model.sqlmodel_update(fields_payload)
+    session.add(model)
     session.commit()
     session.refresh(model)
 

--- a/apps/api/src/db/models.py
+++ b/apps/api/src/db/models.py
@@ -80,26 +80,12 @@ class AgentBase(Base):
 
 
 class AgentUpdate(Base):
-    eliza_agent_id: str | None = Field(description="Eliza's agent id", nullable=True)
-    owner_id: UUID = Field(
-        foreign_key="user.id",
-        description="UUID of the User who owns the agent.",
-        nullable=False,
-    )
-    runtime_id: UUID | None = Field(
-        foreign_key="runtime.id",
-        description="UUID of the runtime the agent uses.",
-        nullable=True,
-    )
-    token_id: UUID | None = Field(
-        foreign_key="token.id",
-        description="UUID of the token the agent uses.",
-        nullable=True,
-    )
-    character_json: Json | None = Field(
-        description="Eliza character json", nullable=True, sa_type=JSON
-    )
-    env_file: str | None = Field(description=".env for the agent", nullable=True)
+    eliza_agent_id: str | None = None
+    owner_id: UUID | None = None
+    runtime_id: UUID | None = None
+    token_id: UUID | None = None
+    character_json: Json | None = None
+    env_file: str | None = None
 
 
 class TokenBase(Base):

--- a/apps/api/src/db/models.py
+++ b/apps/api/src/db/models.py
@@ -80,12 +80,26 @@ class AgentBase(Base):
 
 
 class AgentUpdate(Base):
-    eliza_agent_id: str | None = None
-    owner_id: UUID | None = None
-    runtime_id: UUID | None = None
-    token_id: UUID | None = None
-    character_json: Json | None = None
-    env_file: str | None = None
+    eliza_agent_id: str | None = Field(
+        description="Agent id of the eliza agent (different from Agent.id)",
+        nullable=True,
+        default=None,
+    )
+    owner_id: UUID | None = Field(
+        description="UUID of the User who owns the agent.", nullable=True, default=None
+    )
+    runtime_id: UUID | None = Field(
+        description="UUID of the runtime the agent uses.", nullable=True, default=None
+    )
+    token_id: UUID | None = Field(
+        description="UUID of the token associated with the agent.",
+        nullable=True,
+        default=None,
+    )
+    character_json: Json | None = Field(
+        description="Eliza character json. Json or dict.", nullable=True, default=None
+    )
+    env_file: str | None = Field(description=".env for the agent", nullable=True)
 
 
 class TokenBase(Base):

--- a/apps/api/src/db/setup.py
+++ b/apps/api/src/db/setup.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from contextlib import contextmanager
 
@@ -54,3 +55,6 @@ def init_db():
         dir_path = os.path.dirname(os.path.realpath(__file__))
         alembic_cfg = Config(os.path.join(dir_path, "../../alembic.ini"))
         command.upgrade(alembic_cfg, "head")
+
+        logging.getLogger().setLevel(logging.INFO)
+        logging.getLogger("alembic").propagate = True

--- a/apps/api/src/models.py
+++ b/apps/api/src/models.py
@@ -3,9 +3,8 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field
 
 
-class Character(
-    BaseModel
-):  # TODO: Look at Eliza's character loading to figure out the actual schema for character_json lowk high prio
+# TODO: Look at Eliza's character loading to figure out the actual schema for character_json lowk high prio
+class Character(BaseModel):
     character_json: dict = Field(
         {},
         description="A dictionary representing the character json for the eliza agent",

--- a/apps/api/src/models.py
+++ b/apps/api/src/models.py
@@ -27,6 +27,22 @@ class ChatRequest(BaseModel):
     text: str
 
 
+class ElizaContent(BaseModel):
+    text: str | None = Field(description="Text content of the message")
+    # TODO: Include these additional fields foudn in client-direct/dist/index.js/createApiRouter.
+    # action
+    # source
+
+
+class ElizaMessage(BaseModel):
+    user: str = Field(
+        description=r"User or agent. Potentially a placeholder like {{user1}}"
+    )
+    content: ElizaContent = Field(
+        description="Content of the message, including text and potentially other fields"
+    )
+
+
 class ElizaCharacterJson(BaseModel):
     model_config = ConfigDict(extra="allow")
     name: str

--- a/apps/api/src/server.py
+++ b/apps/api/src/server.py
@@ -1,3 +1,4 @@
+import json
 import os
 from collections.abc import Sequence
 from contextlib import asynccontextmanager
@@ -19,7 +20,7 @@ from src.db.models import (
     UserBase,
     UserUpdate,
 )
-from src.models import Character, TokenCreationRequest
+from src.models import TokenCreationRequest
 from src.setup import test_db_connection
 from src.token_deployment import deploy_token
 
@@ -68,6 +69,23 @@ async def get_agent(agent_id: str) -> Agent:
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
 
+    return agent
+
+
+@app.patch("/agents/{agent_id}")
+async def update_agent(agent_id: str, agent_update: AgentUpdate) -> Agent:
+    """
+    Updates an agent by id.
+    Raises a 404 if the agent is not found.
+    """
+    with Session() as session:
+        agent: Agent | None = crud.get_agent(session, agent_id)
+
+    if not agent:
+        raise HTTPException(status_code=404, detail="Agent not found")
+
+    with Session() as session:
+        agent = crud.update_agent(session, agent, agent_update)
     return agent
 
 
@@ -150,9 +168,9 @@ def create_runtime() -> Runtime:
     next_runtime_number = runtime_count + 1
     try:
         if os.getenv("ENV") == "staging":
-            url = "https://api.github.com/repos/abstractoperators/aiden/actions/workflows/create-new-runtime-staging.yaml/dispatches"
+            url = "https://api.github.com/repos/abstractoperators/aiden/actions/workflows/145628373/dispatches"
         elif os.getenv("ENV") == "prod":
-            url = "https://api.github.com/repos/abstractoperators/aiden/actions/workflows/144070661"
+            url = "https://api.github.com/repos/abstractoperators/aiden/actions/workflows/144070661/dispatches"
         print(url)
         print(next_runtime_number)
         resp = requests.post(
@@ -163,7 +181,7 @@ def create_runtime() -> Runtime:
                 "X-GitHub-Api-Version": "2022-11-28",
             },
             json={
-                "ref": "refs/heads/michael/prod",
+                "ref": "michael/prod",
                 "inputs": {
                     "service-no": str(next_runtime_number),
                 },
@@ -218,17 +236,19 @@ def start_agent(agent_id: str, runtime_id: str) -> tuple[Agent, Runtime]:
         if old_agent:
             stop_endpoint = f"{runtime.url}/controller/character/stop"
             requests.post(stop_endpoint)
-            crud.update_agent(session, old_agent, AgentUpdate(runtime_id=None))
+            crud.update_agent(
+                session,
+                old_agent,
+                AgentUpdate(runtime_id=None),
+            )
 
-    start_endpoint = f"{runtime.url}/controller/character/start"
+        start_endpoint = f"{runtime.url}/controller/character/start"
 
     # Start the new agent
+    character_json = json.dumps(agent.character_json)
     resp = requests.post(
         start_endpoint,
-        Character(
-            character_json=agent.character_json,
-            envs=agent.env_file,
-        ).model_dump_json(),
+        json={"character_json": character_json, "envs": agent.env_file},
     )
     eliza_agent_id = resp.json().get("agent_id")
     # Update the agent to have a runtime now

--- a/apps/api/src/server.py
+++ b/apps/api/src/server.py
@@ -150,9 +150,9 @@ def create_runtime() -> Runtime:
     next_runtime_number = runtime_count + 1
     try:
         if os.getenv("ENV") == "staging":
-            url = "https://api.github.com/repos/abstractoperators/aiden/actions/workflows/144070661/dispatches"
-        else:
-            url = ""  # TODO
+            url = "https://api.github.com/repos/abstractoperators/aiden/actions/workflows/145628373"
+        elif os.getenv("ENV") == "prod":
+            url = "https://api.github.com/repos/abstractoperators/aiden/actions/workflows/144070661"
         resp = requests.post(
             url=url,
             headers={
@@ -161,7 +161,7 @@ def create_runtime() -> Runtime:
                 "X-GitHub-Api-Version": "2022-11-28",
             },
             json={
-                "ref": "michael/crud-agents",
+                "ref": "main",
                 "inputs": {
                     "service-no": str(next_runtime_number),
                 },

--- a/apps/api/src/server.py
+++ b/apps/api/src/server.py
@@ -21,7 +21,6 @@ from src.db.models import (
 )
 from src.models import Character, TokenCreationRequest
 from src.setup import test_db_connection
-
 from src.token_deployment import deploy_token
 
 
@@ -150,8 +149,12 @@ def create_runtime() -> Runtime:
     GITHUB_WORKFLOW_DISPATCH_PAT = os.getenv("GITHUB_WORKFLOW_DISPATCH_PAT")
     next_runtime_number = runtime_count + 1
     try:
+        if os.getenv("ENV") == "staging":
+            url = "https://api.github.com/repos/abstractoperators/aiden/actions/workflows/144070661/dispatches"
+        else:
+            url = ""  # TODO
         resp = requests.post(
-            "https://api.github.com/repos/abstractoperators/aiden/actions/workflows/144070661/dispatches",
+            url=url,
             headers={
                 "Accept": "application/vnd.github+json",
                 "Authorization": f"Bearer {GITHUB_WORKFLOW_DISPATCH_PAT}",

--- a/apps/api/src/server.py
+++ b/apps/api/src/server.py
@@ -181,7 +181,7 @@ def create_runtime() -> Runtime:
                 "X-GitHub-Api-Version": "2022-11-28",
             },
             json={
-                "ref": "michael/prod",
+                "ref": "main",
                 "inputs": {
                     "service-no": str(next_runtime_number),
                 },

--- a/apps/api/src/server.py
+++ b/apps/api/src/server.py
@@ -150,9 +150,11 @@ def create_runtime() -> Runtime:
     next_runtime_number = runtime_count + 1
     try:
         if os.getenv("ENV") == "staging":
-            url = "https://api.github.com/repos/abstractoperators/aiden/actions/workflows/145628373"
+            url = "https://api.github.com/repos/abstractoperators/aiden/actions/workflows/create-new-runtime-staging.yaml/dispatches"
         elif os.getenv("ENV") == "prod":
             url = "https://api.github.com/repos/abstractoperators/aiden/actions/workflows/144070661"
+        print(url)
+        print(next_runtime_number)
         resp = requests.post(
             url=url,
             headers={
@@ -161,7 +163,7 @@ def create_runtime() -> Runtime:
                 "X-GitHub-Api-Version": "2022-11-28",
             },
             json={
-                "ref": "main",
+                "ref": "refs/heads/michael/prod",
                 "inputs": {
                     "service-no": str(next_runtime_number),
                 },
@@ -171,7 +173,7 @@ def create_runtime() -> Runtime:
         resp.raise_for_status()
     except Exception as e:
         logger.error(e)
-        raise HTTPException(status_code=500, detail="Failed to start the runtime")
+        raise HTTPException(status_code=400, detail=f"Failed to start the runtime {e}")
 
     # TODO: Verify completion of the github action, and that the runtime is up and running
 

--- a/apps/api/src/token_deployment.py
+++ b/apps/api/src/token_deployment.py
@@ -1,9 +1,11 @@
-import os
 import json
-from web3 import AsyncWeb3, AsyncHTTPProvider
+import os
+
 from eth_account import Account
+from web3 import AsyncHTTPProvider, AsyncWeb3
 
 SEI_RPC_URL = os.getenv("SEI_RPC_URL")  # Get the SEI EVM RPC URL
+
 
 # Connects to SEI's EVM RPC and deploys a new instance of the token contract.
 async def deploy_token(name, ticker):
@@ -18,7 +20,10 @@ async def deploy_token(name, ticker):
         raise ConnectionError("Failed to connect to Sei Network")
 
     # Load ABI and bytecode
-    with open("./src/bonding_token/artifacts/contracts/BondingCurveToken.sol/BondingCurveToken.json", "r") as f:
+    with open(
+        "./src/bonding_token/artifacts/contracts/BondingCurveToken.sol/BondingCurveToken.json",
+        "r",
+    ) as f:
         contract_json = json.load(f)
     contract_abi = contract_json["abi"]
     contract_bytecode = contract_json["bytecode"]
@@ -34,17 +39,19 @@ async def deploy_token(name, ticker):
     gas_price = await w3.eth.gas_price
     chain_id = await w3.eth.chain_id
     # Build transaction with the given name and ticker
-    deploy_txn = await contract.constructor(name, ticker).build_transaction({
-        'from': deployer_address,
-        'nonce': nonce,
-        'gas': 5000000,
-        'gasPrice': gas_price,
-        'chainId': chain_id
-    })
+    deploy_txn = await contract.constructor(name, ticker).build_transaction(
+        {
+            "from": deployer_address,
+            "nonce": nonce,
+            "gas": 5000000,
+            "gasPrice": gas_price,
+            "chainId": chain_id,
+        }
+    )
 
     # Sign and send deployment transaction
     signed_txn = w3.eth.account.sign_transaction(deploy_txn, PRIVATE_KEY)
-    tx_hash = await w3.eth.send_raw_transaction(signed_txn.rawTransaction)
+    tx_hash = await w3.eth.send_raw_transaction(signed_txn.raw_transaction)
     print(f"Deployment TX sent: {tx_hash.hex()}")
 
     # Wait for deployment receipt
@@ -58,6 +65,7 @@ async def deploy_token(name, ticker):
     print(receipt)
 
     return contract_address
+
 
 async def buy_token(buy_amount, contract_address):
     w3 = AsyncWeb3(AsyncHTTPProvider(SEI_RPC_URL))
@@ -76,17 +84,17 @@ async def buy_token(buy_amount, contract_address):
     chain_id = await w3.eth.chain_id
 
     buy_txn = {
-        'to': contract_address,
-        'value': buy_amount,
-        'from': deployer_address,
-        'nonce': nonce,
-        'gas': 300000,
-        'gasPrice': gas_price,
-        'chainId': chain_id
+        "to": contract_address,
+        "value": buy_amount,
+        "from": deployer_address,
+        "nonce": nonce,
+        "gas": 300000,
+        "gasPrice": gas_price,
+        "chainId": chain_id,
     }
 
     signed_buy_txn = w3.eth.account.sign_transaction(buy_txn, PRIVATE_KEY)
-    buy_tx_hash = await w3.eth.send_raw_transaction(signed_buy_txn.rawTransaction)
+    buy_tx_hash = await w3.eth.send_raw_transaction(signed_buy_txn.raw_transaction)
     print(f"Buy transaction sent: {buy_tx_hash.hex()}")
 
     buy_receipt = await w3.eth.wait_for_transaction_receipt(buy_tx_hash)

--- a/apps/runtime/nginx.conf
+++ b/apps/runtime/nginx.conf
@@ -29,6 +29,32 @@ http {
             proxy_set_header Host $host;
             proxy_cache_bypass $http_upgrade;
         }
+        
+        location /redoc {
+            proxy_pass http://localhost:8000;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection 'upgrade';
+            proxy_set_header Host $host;
+            proxy_cache_bypass $http_upgrade;
+        }
+        location /docs {
+            proxy_pass http://localhost:8000;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection 'upgrade';
+            proxy_set_header Host $host;
+            proxy_cache_bypass $http_upgrade;
+        }
+
+        location /openapi.json {
+            proxy_pass http://localhost:8000;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection 'upgrade';
+            proxy_set_header Host $host;
+            proxy_cache_bypass $http_upgrade;
+        }
 
         location / {
             proxy_pass http://localhost:3000;

--- a/apps/runtime/src/server.py
+++ b/apps/runtime/src/server.py
@@ -57,7 +57,7 @@ def get_character_status() -> CharacterStatus:
     if agent_runtime_subprocess and agent_runtime_subprocess.poll() is None:
         try:
             agents = requests.get("http://localhost:3000/agents").json().get("agents")
-            agent_id = agents[0].get("id") if agents else None
+            agent_id = agents[0].get("id") if agents else ""
         except requests.exceptions.ConnectionError:
             return CharacterStatus(running=False)
         return CharacterStatus(running=True, agent_id=agent_id)
@@ -108,7 +108,7 @@ def start_character(character: Character) -> CharacterStatus:
     )
 
 
-@router.post("/character/read")
+@router.get("/character/read")
 def read_character() -> Character:
     """
     Returns the configuration for the current character


### PR DESCRIPTION
Create github actions script for:
- Forcing redeployment for prod frontend and api server
- Creating a new runtime service in prod
   - Technically, changed existing create-new-runtime-service.yaml to actually deploy to prod instead of staging
   - Created new create-new-runtime-service-staging.yaml
 
Added alembic migration + apply alembic migration on server startup

API Server:
- Add `PATCH /agents/{agent_id}`
- Update `create_runtime` to use the correct github actions script depending on env


Runtime Server(s):
- Make `/docs` and `/redoc` work
- Update `read_character` to use `GET` HTTP method

