### PR TITLE
Change AgentUpdate.character_json to be of type dict instead Json

### DIFF
--- a/apps/api/src/db/models.py
+++ b/apps/api/src/db/models.py
@@ -108,7 +108,7 @@ class AgentUpdate(Base):
         nullable=True,
         default=None,
     )
-    character_json: Json | None = Field(
+    character_json: dict | None = Field(
         description="Eliza character json. Json or dict.", nullable=True, default=None
     )
     env_file: str | None = Field(


### PR DESCRIPTION
Reconciles difference between AgentBase.character_json: dict and AgentUpdate.character_json: Json (json escaped string)