### PR TITLE
Fix Get User

### DIFF
--- a/apps/api/src/server.py
+++ b/apps/api/src/server.py
@@ -530,7 +530,7 @@ async def get_users() -> Sequence[User]:
     return users
 
 
-@app.get("/users/{user_id}")
+@app.get("/users")
 async def get_user(user_id: UUID) -> User:
     """
     Returns a user by id.
@@ -545,7 +545,7 @@ async def get_user(user_id: UUID) -> User:
     return user
 
 
-@app.get("/users/{public_key}")
+@app.get("/users")
 async def get_user_by_public_key(public_key: str) -> User:
     """
     Returns a user by public key.

--- a/apps/api/src/server.py
+++ b/apps/api/src/server.py
@@ -10,6 +10,7 @@ from uuid import UUID
 import requests
 from boto3 import Session as Boto3Session
 from fastapi import BackgroundTasks, FastAPI, HTTPException, Request
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from mypy_boto3_ecs.client import ECSClient
 from mypy_boto3_elbv2.client import ElasticLoadBalancingv2Client as ELBv2Client
@@ -104,6 +105,22 @@ instrumentator.add(metrics.request_size())
 instrumentator.add(metrics.response_size())
 
 instrumentator.instrument(app).expose(app)
+
+# TODO: Change this based on env
+if os.getenv("ENV") == "dev":
+    allowed_origins = ["http://localhost:8001"]
+elif os.getenv("ENV") == "staging":
+    allowed_origins = ["https://staigen.space"]
+elif os.getenv("ENV") == "prod":
+    allowed_origins = ["https://aiden.space"]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=allowed_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 @app.get("/ping")

--- a/apps/api/src/server.py
+++ b/apps/api/src/server.py
@@ -108,7 +108,7 @@ instrumentator.instrument(app).expose(app)
 
 # TODO: Change this based on env
 if os.getenv("ENV") == "dev":
-    allowed_origins = ["http://localhost:8001"]
+    allowed_origins = ["http://localhost:3000", "http://localhost:8001"]
 elif os.getenv("ENV") == "staging":
     allowed_origins = ["https://staigen.space"]
 elif os.getenv("ENV") == "prod":
@@ -541,7 +541,7 @@ async def create_user(user: UserBase) -> User:
 async def get_user(
     user_id: UUID | None = None,
     public_key: str | None = None,
-) -> User:
+) -> User | Sequence[User]:
     """
     Returns all users if neither user_id nor public_key are passed
     Returns a user by id if user_id is passed


### PR DESCRIPTION
added localhost:3000 to CORs for api/server. localhost:3000 needed for local FE work (no docker)

fixed response validation for API's `GET /users` endpoint