### PR TITLE
Login bugfix

### DIFF
--- a/apps/frontend/components/dynamic/provider.tsx
+++ b/apps/frontend/components/dynamic/provider.tsx
@@ -62,7 +62,7 @@ export default function DynamicProvider({ children }: React.PropsWithChildren) {
             })
             .then((res) => {
               if (res.ok) {
-                console.log('LOGGED IN', res);
+                console.debug('LOGGED IN', res);
                 // Handle success - maybe redirect to the home page or user dashboard
               } else {
                 // Handle any errors - maybe show an error message to the user

--- a/apps/frontend/components/dynamic/provider.tsx
+++ b/apps/frontend/components/dynamic/provider.tsx
@@ -89,6 +89,12 @@ export default function DynamicProvider({ children }: React.PropsWithChildren) {
                     ownerId: validUser.id,
                   }
                 )
+              } else {
+                console.debug(`User ${validUser.id} has no primary wallet!`)
+                toast({
+                  title: "You don't have a wallet!",
+                  description: "Some functionality might not be available for you; please add a wallet to your account to enjoy the full AIDN experience.",
+                })
               }
             } else { toast({
               title: "Login error!",
@@ -157,10 +163,7 @@ export default function DynamicProvider({ children }: React.PropsWithChildren) {
             // const user = session.user
 
             if (isErrorResult(user)) {
-              toast({
-                title: "Unable to add wallet to AIDN user",
-                description: user.message,
-              })
+              console.error(`Unable to add wallet to AIDN user: ${user.message}. If user is logging in, can probably disregard this.`)
               return
             }
 

--- a/apps/frontend/lib/api/wallet.ts
+++ b/apps/frontend/lib/api/wallet.ts
@@ -71,8 +71,9 @@ async function updateOrCreateWallet(
   }
 
   const apiWallet = await getWallet(id)
-  if (isErrorResult(apiWallet))
-    return apiWallet
+  if (isErrorResult(apiWallet)) {
+    return isNotFound(apiWallet) ? createWallet(wallet) : apiWallet
+  }
   
   return updateWallet(
     apiWallet.data.id,


### PR DESCRIPTION
Wallets weren't being initialized properly due to a bug in `apps/frontend/lib/api/wallet.ts:updateOrCreateWallet`. For the type of payload passed in for wallet initialization during the login process, the function would return the error if a wallet wasn't found instead of creating it.