### PR TITLE
Frontend Prod Deploy Bugfix

### DIFF
--- a/.github/workflows/deploy-frontend-to-prod.yaml
+++ b/.github/workflows/deploy-frontend-to-prod.yaml
@@ -41,6 +41,7 @@ jobs:
                   make aws-ecr-push-frontend-prod
 
     force-redeployment:
+        needs: build-and-push-frontend
         runs-on: ubuntu-latest
         steps:
             - name: Configure aws credentials


### PR DESCRIPTION
The GHA for frontend prod was not working properly because the redeploy would happen at the same time as the image build and push. It should wait for the image to be rebuilt before being redeployed.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add dependency in `deploy-frontend-to-prod.yaml` to ensure `force-redeployment` waits for `build-and-push-frontend`.
> 
>   - **Workflow Change**:
>     - In `.github/workflows/deploy-frontend-to-prod.yaml`, added `needs: build-and-push-frontend` to `force-redeployment` job.
>     - Ensures `force-redeployment` waits for `build-and-push-frontend` to complete before executing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=abstractoperators%2Faiden&utm_source=github&utm_medium=referral)<sup> for 9c553fb16dfb51653c5a04505d7e6d08f42322e4. You can [customize](https://app.ellipsis.dev/abstractoperators/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->