### PR TITLE
runtime dockerfile fix

### DIFF
--- a/apps/runtime/Dockerfile.runtime
+++ b/apps/runtime/Dockerfile.runtime
@@ -15,7 +15,7 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 WORKDIR /app
 
 # Copy package.json and other configuration files
-COPY eliza/package.json eliza/pnpm-lock.yaml eliza/pnpm-workspace.yaml eliza/.npmrc eliza/turbo.json ./
+COPY eliza/package.json eliza/pnpm-lock.yaml eliza/pnpm-workspace.yaml eliza/.npmrc eliza/turbo.json eliza/tsconfig.json ./
 
 # Copy the rest of the application code
 COPY eliza/agent ./agent
@@ -48,6 +48,7 @@ COPY --from=builder /app/package.json ./eliza
 COPY --from=builder /app/pnpm-workspace.yaml ./eliza
 COPY --from=builder /app/.npmrc ./eliza
 COPY --from=builder /app/turbo.json ./eliza
+COPY --from=builder /app/tsconfig.json ./eliza
 COPY --from=builder /app/node_modules ./eliza/node_modules
 COPY --from=builder /app/agent ./eliza/agent
 COPY --from=builder /app/client ./eliza/client

--- a/apps/runtime/Dockerfile.runtime
+++ b/apps/runtime/Dockerfile.runtime
@@ -48,7 +48,6 @@ COPY --from=builder /app/package.json ./eliza
 COPY --from=builder /app/pnpm-workspace.yaml ./eliza
 COPY --from=builder /app/.npmrc ./eliza
 COPY --from=builder /app/turbo.json ./eliza
-COPY --from=builder /app/tsconfig.json ./eliza
 COPY --from=builder /app/node_modules ./eliza/node_modules
 COPY --from=builder /app/agent ./eliza/agent
 COPY --from=builder /app/client ./eliza/client


### PR DESCRIPTION
new eliza builds require the root `tsconfg.json` file, so we copy it into the docker builder stage.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `eliza/tsconfig.json` to `Dockerfile.runtime` to support new Eliza builds.
> 
>   - **Dockerfile Changes**:
>     - Add `eliza/tsconfig.json` to the `COPY` command in `Dockerfile.runtime` to support new Eliza builds.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=abstractoperators%2Faiden&utm_source=github&utm_medium=referral)<sup> for 8e3449bbc08c338547f5a5c071fbdff8043ad39c. You can [customize](https://app.ellipsis.dev/abstractoperators/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->