### PR TITLE
Limit agent creation to one per user

### DIFF
--- a/apps/api/src/auth.py
+++ b/apps/api/src/auth.py
@@ -181,3 +181,11 @@ def check_scopes(
             )
         return None
     return helper
+
+
+def get_scopes(
+    token: HTTPAuthorizationCredentials = Security(auth_scheme),
+) -> set[str]:
+    payload = parse_jwt(token)
+    scopes_list = (payload.get("lists", []))
+    return set(scopes_list)

--- a/apps/api/src/test_endpoints.py
+++ b/apps/api/src/test_endpoints.py
@@ -447,6 +447,7 @@ async def test_agents(
     # Make a random agent with a different owner.
     random_user: UserPublic = user_factory()
     agent_factory(owner_id=random_user.id)
+    # this second one should fail due to agent creation limits
     agent_factory(owner_id=random_user.id)
 
     response = client.get(f"/agents/{agent.id}")

--- a/apps/frontend/app/user/agents/creation/page.tsx
+++ b/apps/frontend/app/user/agents/creation/page.tsx
@@ -1,12 +1,47 @@
+import { getEnlightened } from "@/lib/api/agent";
 import FormTabs from "./tabs";
+import { auth } from "@/auth";
+import { getUser } from "@/lib/api/user";
+import { isErrorResult, isSuccessResult } from "@/lib/api/result";
 
-export default function AgentCreation() {
+export default async function AgentCreation() {
+  // TODO consider removing in favor of context/context provider
+  const session = await auth()
+  if (!session)
+    throw new Error(`Session ${JSON.stringify(session)} does not exist!`)
+  if (!session.user)
+    throw new Error(`Session ${JSON.stringify(session)} does not have a user!`)
+  if (!session.user.id)
+    throw new Error(`Session user ${JSON.stringify(session.user)} does not have an ID!`)
+  if (!session.user.scopes)
+    throw new Error(`Session user ${JSON.stringify(session.user)} does not have scopes!`)
+
+  const userResult = await getUser({dynamicId: session.user.id})
+
+  if (isErrorResult(userResult)) { return (
+    <div>
+      <h1>Unable to retrieve AIDN user!</h1>
+      <h2>{userResult.message}</h2>
+    </div>
+  )}
+
+  const user = userResult.data
+  const userAgents = await getEnlightened({userId: user.id})
+
   return (
     <div className="my-16 mx-16">
       <h1 className="text-3xl font-bold tracking-tight sm:text-4xl md:text-5xl lg:text-6xl my-8">
         Create an Agent
       </h1>
-      <FormTabs />
+      {
+        isSuccessResult(userAgents) ?
+        (
+          userAgents.data.length > 0 && !session.user.scopes.includes('admin') ?
+          <h2>You may only have one agent at a time!</h2> :
+          <FormTabs />
+        ) :
+        <h2>Unable to prepare agent creation form!</h2>
+      }
     </div>
   )
 }

--- a/apps/frontend/app/user/agents/creation/page.tsx
+++ b/apps/frontend/app/user/agents/creation/page.tsx
@@ -8,7 +8,7 @@ export default async function AgentCreation() {
   // TODO consider removing in favor of context/context provider
   const session = await auth()
   if (!session)
-    throw new Error(`Session ${JSON.stringify(session)} does not exist!`)
+    throw new Error('Session does not exist!')
   if (!session.user)
     throw new Error(`Session ${JSON.stringify(session)} does not have a user!`)
   if (!session.user.id)


### PR DESCRIPTION
Restrict agent creation to one per user at the API level. Admins have unlimited agent creation, and on the frontend users should receive an error message when they try to create an agent that would exceed their limit.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Limit agent creation to one per user, with exceptions for admins, and update backend and frontend to enforce this rule.
> 
>   - **Backend**:
>     - In `server.py`, `create_agent()` now checks if a user already has an agent and raises a 403 error if they do, unless the user has 'admin' scope.
>     - Adds `get_scopes()` in `auth.py` to extract user scopes from JWT.
>   - **Frontend**:
>     - In `page.tsx`, checks if a user already has an agent and displays a message if they exceed the limit, unless they are an admin.
>   - **Tests**:
>     - In `test_endpoints.py`, adds a test to ensure agent creation fails for non-admin users who already have an agent.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=abstractoperators%2Faiden&utm_source=github&utm_medium=referral)<sup> for d90f4292791c6e8b5559cad8d2732df910d5aebe. You can [customize](https://app.ellipsis.dev/abstractoperators/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->