### PR TITLE
Bugfix: Users unable to login after FastAPI Dependency Refactor

### DIFF
--- a/apps/api/src/server.py
+++ b/apps/api/src/server.py
@@ -129,7 +129,8 @@ env = os.getenv("ENV")
 if env == "dev" or env == "test":
     allowed_origins = ["http://localhost:3000", "http://localhost:8001"]
 elif env == "staging":
-    allowed_origins = ["https://staigen.space"]
+    allowed_origins = ["http://localhost:3000", "http://localhost:8001"]
+    # allowed_origins = ["https://staigen.space"]
 elif env == "prod":
     allowed_origins = ["https://aidn.fun"]
 else:
@@ -676,7 +677,7 @@ async def delete_wallet(
 @app.post("/users")
 async def create_user(
     user: UserBase,
-    decoded_token: Annotated[dict[str, Any], Security(parse_jwt)],
+    decoded_token: Annotated[dict[str, Any], Security(parse_jwt())],
     is_admin: IsAdminDepends,
 ) -> User:
     """

--- a/apps/api/src/server.py
+++ b/apps/api/src/server.py
@@ -129,8 +129,7 @@ env = os.getenv("ENV")
 if env == "dev" or env == "test":
     allowed_origins = ["http://localhost:3000", "http://localhost:8001"]
 elif env == "staging":
-    allowed_origins = ["http://localhost:3000", "http://localhost:8001"]
-    # allowed_origins = ["https://staigen.space"]
+    allowed_origins = ["https://staigen.space"]
 elif env == "prod":
     allowed_origins = ["https://aidn.fun"]
 else:


### PR DESCRIPTION
The Security Dependency `parse_jwt` needs to be called with boolean keyword argument `required`. By default it is `True`.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes user login issue by correctly invoking `parse_jwt()` in `create_user()` in `server.py`.
> 
>   - **Bug Fix**:
>     - Fixes user login issue by calling `parse_jwt()` with `required=True` in `create_user()` in `server.py`.
>     - Ensures `parse_jwt` is invoked as a function rather than a reference.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=abstractoperators%2Faiden&utm_source=github&utm_medium=referral)<sup> for f4632628912a429b26d53e3280f8af96a7bc6eeb. You can [customize](https://app.ellipsis.dev/abstractoperators/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->