### PR TITLE
Topics Card and Adjectives Card Bug Fix

### DIFF
--- a/apps/frontend/components/agent-tag-card.tsx
+++ b/apps/frontend/components/agent-tag-card.tsx
@@ -8,7 +8,7 @@ export default function TagCard({
   tags: string[],
   title: string,
 }) {
-  const strippedTags = tags.filter(str => str.length)
+  const strippedTags = tags.filter(str => str.trim().length)
   return (
     <Card>
       <CardHeader>


### PR DESCRIPTION
Wasn't aware that by default items don't wrap in their container. That's why the tags in the topics card and adjectives card stick out.

It's fixed now, and empty tags also don't show up anymore either.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes tag wrapping and filters out empty tags in `agent-tag-card.tsx`.
> 
>   - **Behavior**:
>     - Tags now wrap within their container in `agent-tag-card.tsx` by adding `flex-wrap` to `CardContent`.
>     - Empty tags are filtered out using `strippedTags` in `agent-tag-card.tsx`.
>   - **Misc**:
>     - Minor layout adjustment in `agent-tag-card.tsx` to prevent tags from sticking out.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=abstractoperators%2Faiden&utm_source=github&utm_medium=referral)<sup> for 6a5f51bb0fb6eb7e6989edffdce4512927e364ac. You can [customize](https://app.ellipsis.dev/abstractoperators/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->