### PR TITLE
Make error handling for already deleted runtime more precise

### DIFF
--- a/apps/api/src/tasks.py
+++ b/apps/api/src/tasks.py
@@ -371,7 +371,8 @@ def delete_runtime(
                     cluster=aws_config.cluster,
                     services=[aws_config.service_name],
                 )
-            except botocore.errorfactory.ServiceNotFoundException:
+            except ecs_client.exceptions.ClientError as error:
+                logger.error(error)
                 logger.warning(f"AWS resource not found for {runtime_id}. Maybe it was already deleted?")
 
         # Delete the listener rules


### PR DESCRIPTION
Encountered this while cleaning up the staging environment. Going to test it out shortly after on staging to confirm that the log is going through to AWS as expected.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhance error handling in `delete_runtime()` by logging `ClientError` and warning if AWS resource might already be deleted.
> 
>   - **Error Handling**:
>     - In `delete_runtime()` in `tasks.py`, wrap `ecs_client.delete_service` and `waiter.wait` in a try-except block.
>     - Log `ClientError` and issue a warning if AWS resource not found, suggesting it might be already deleted.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=abstractoperators%2Faiden&utm_source=github&utm_medium=referral)<sup> for 825f87969e96555985630e921256ef6d07409b88. You can [customize](https://app.ellipsis.dev/abstractoperators/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->